### PR TITLE
[BIOMAGE-1282] Add create and delete metadata test

### DIFF
--- a/e2e/cypress/integration/ui-smoke/ui-create-delete-metadata.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-create-delete-metadata.spec.js
@@ -38,7 +38,7 @@ describe('Adds metadata to a sample in a created project', () => {
   });
 
   it('creates a new metadata track', () => {
-    const projectName = 'cypressTestProject';
+    const projectName = 'IntTest - Add Metadata Project';
     const metadataKeysArray = ['Track_1'];
 
     cy.selectProject(projectName);
@@ -60,7 +60,7 @@ describe('Adds metadata to a sample in a created project', () => {
   });
 
   it('deletes an existing metadata track', () => {
-    const projectName = 'cypressTestProject';
+    const projectName = 'IntTest - Add Metadata Project';
     const emptyMetadataKeysArray = [];
 
     cy.selectProject(projectName);

--- a/e2e/cypress/integration/ui-smoke/ui-create-delete-metadata.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-create-delete-metadata.spec.js
@@ -1,0 +1,83 @@
+/// <reference types="cypress" />
+import '../../support/commands';
+import successResponse from '../../fixtures/successResponse.json';
+
+const resizeObserverLoopErrRe = /ResizeObserver loop limit exceeded/;
+
+describe('Adds metadata to a sample in a created project', () => {
+  // before each test:
+  //   1. set up the network intercepts
+  //   2. Log in into biomage
+  //   3. Visit data-management
+  beforeEach(() => {
+    // Intercept PUT/DELETE calls to */project/* endpoint
+    cy.intercept(
+      {
+        method: 'PUT',
+        url: '*/projects/*',
+      },
+    ).as('putProject');
+
+    cy.intercept(
+      {
+        method: 'DELETE',
+        url: '*/projects/*',
+      },
+    ).as('deleteProject');
+
+    cy.login();
+    cy.visit('/data-management');
+  });
+
+  // we have some kind of resize observer loop error that needs looking into
+  Cypress.on('uncaught:exception', (err) => {
+    if (resizeObserverLoopErrRe.test(err.message)) {
+      return false;
+    }
+    return true;
+  });
+
+  it('creates a new metadata track', () => {
+    const projectName = 'cypressTestProject';
+    const metadataKeysArray = ['Track_1'];
+
+    cy.selectProject(projectName);
+    cy.addMetadata('testMetadataName');
+
+    // check that req/response are correct
+    cy.wait('@putProject').should(({ request, response }) => {
+      expect(request.method).to.equal('PUT');
+      expect(request.body).to.have.property('name', projectName);
+      expect(request.body).to.have.property('metadataKeys');
+      expect(request.body.metadataKeys).to.deep.equal(metadataKeysArray);
+      expect(response.body).to.deep.equal(successResponse);
+    });
+
+    // Check that the current active project contains the project title & description
+    cy.get('.ant-table-container').should((antTableContainer) => {
+      expect(antTableContainer).to.contain('Track 1');
+    });
+  });
+
+  it('deletes an existing metadata track', () => {
+    const projectName = 'cypressTestProject';
+    const emptyMetadataKeysArray = [];
+
+    cy.selectProject(projectName);
+    cy.deleteMetadata('Track_1');
+
+    // check that req/response are correct
+    cy.wait('@putProject').should(({ request, response }) => {
+      expect(request.method).to.equal('PUT');
+      expect(request.body).to.have.property('name', projectName);
+      expect(request.body).to.have.property('metadataKeys');
+      expect(request.body.metadataKeys).to.deep.equal(emptyMetadataKeysArray);
+      expect(response.body).to.deep.equal(successResponse);
+    });
+
+    // Check that the current active project contains the project title & description
+    cy.get('.ant-table-container').should((antTableContainer) => {
+      expect(antTableContainer).to.not.contain('Track 1');
+    });
+  });
+});

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -98,7 +98,7 @@ Cypress.Commands.add('selectProject', (projectName) => {
     autoEnd: false,
   });
 
-  cy.get(`[data-test-id="project-card-${projectName}"]`).click();
+  cy.get('[data-test-class="project-card"]').contains(projectName).click();
 
   log.end();
 });

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -98,7 +98,7 @@ Cypress.Commands.add('selectProject', (projectName) => {
     autoEnd: false,
   });
 
-  cy.get(`[data-test-id="${projectName}"]`).click();
+  cy.get(`[data-test-id="project-card-${projectName}"]`).click();
 
   log.end();
 });

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -110,7 +110,7 @@ Cypress.Commands.add('addMetadata', () => {
     autoEnd: false,
   });
 
-  cy.get('#add-metadata-button').click();
+  cy.contains('button', 'Add metadata').click();
 
   log.snapshot('opened-add-metadata-popover');
 

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -98,7 +98,7 @@ Cypress.Commands.add('selectProject', (projectName) => {
     autoEnd: false,
   });
 
-  cy.contains('.project-card', projectName).click();
+  cy.get(`[data-test-id="${projectName}"]`).click();
 
   log.end();
 });

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -90,3 +90,47 @@ Cypress.Commands.add('deleteProject', (projectName) => {
   cy.contains('Permanently delete project').click();
   log.end();
 });
+
+Cypress.Commands.add('selectProject', (projectName) => {
+  const log = Cypress.log({
+    displayName: 'Selecting project',
+    message: [`🔐 Selecting project named ${projectName}`],
+    autoEnd: false,
+  });
+
+  cy.contains('.project-card', projectName).click();
+
+  log.end();
+});
+
+Cypress.Commands.add('addMetadata', () => {
+  const log = Cypress.log({
+    displayName: 'Adding metadata',
+    message: ['🔐 Adding metadata track'],
+    autoEnd: false,
+  });
+
+  cy.get('#add-metadata-button').click();
+
+  log.snapshot('opened-add-metadata-popover');
+
+  cy.contains('.ant-popover', 'Provide new metadata track name').find('.anticon-check').click();
+
+  log.snapshot('closed-add-metadata-popover');
+
+  log.end();
+});
+
+Cypress.Commands.add('deleteMetadata', (metadataTrackName) => {
+  const log = Cypress.log({
+    displayName: 'Adding metadata',
+    message: [`🔐 Adding metadata track named ${metadataTrackName}`],
+    autoEnd: false,
+  });
+
+  cy.contains('.ant-table-cell', 'Track 1').find('.anticon-delete').click();
+
+  log.snapshot('deleted-metadata');
+
+  log.end();
+});


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1282

#### Link to staging deployment URL 
https://ui-martinfosco-ui457.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/ui/pull/457

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
