### PR TITLE
[BIOMAGE-748] Add releasing

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -8,9 +8,10 @@ on:
         required: false
         default: 'production'
       ref:
-        description: 'The ref to the code to be run. Can be any git ref like a branch name, tag, or commit. (default: latest tag for production tests, and master for staging).'
+        description: 'By default the script runs the latest tag when the environment is production, and latest branch commit otherwise.
+         Set this variable to override that behavior and run a specific ref regardless of the environment.'
         required: false
-        default: 'latest_tag'
+        default: ''
   schedule:
     - cron:  '22 2 * * *'
 
@@ -22,19 +23,20 @@ jobs:
       - id: checkout
         name: Check out source code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - id: checkout-correct-ref
         name: Check out the correct test code ref
         run: |-
           # if we are in production check out the latest tag for the nightly build
-          # if we are in staging and we have no ref (default value) just use master (no need to checkout anything)
-          if [ "$REF" = "latest_tag" && "$ENV" == "production" ]; then
-            latesttag=$(git describe --tags)
+          if [ "$ENV" = "production" ] && [ "$REF" = "" ]; then
+            latesttag=$(git describe --tags --abbrev=0)
             echo "Checking out ${latesttag}"
             git checkout ${latesttag}
           fi
-          # if any ref was provided check it out
-          if [ "$REF" != "latest_tag" ]; then
+          # # if any ref was provided check it out
+          if [ "$REF" != "" ]; then
             echo "Checking out $REF"
             git checkout $REF
           fi

--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -7,17 +7,40 @@ on:
         description: 'The environment to run the tests on (staging, production)'
         required: false
         default: 'production'
+      ref:
+        description: 'The ref to the code to be run. Can be any git ref like a branch name, tag, or commit. (default: latest tag for production tests, and master for staging).'
+        required: false
+        default: 'latest_tag'
   schedule:
     - cron:  '22 2 * * *'
 
 jobs:
   run-e2e:
-    name: ${{ format('Run e2e tests for {0}', github.event.inputs.environment || 'production') }}
+    name: ${{ format('Run e2e tests for {0}', github.event.inputs.environment) }}
     runs-on: ubuntu-20.04
     steps:
       - id: checkout
         name: Check out source code
         uses: actions/checkout@v2
+
+      - id: checkout-correct-ref
+        name: Check out the correct test code ref
+        run: |-
+          # if we are in production check out the latest tag for the nightly build
+          # if we are in staging and we have no ref (default value) just use master (no need to checkout anything)
+          if [ "$REF" = "latest_tag" && "$ENV" == "production" ]; then
+            latesttag=$(git describe --tags)
+            echo "Checking out ${latesttag}"
+            git checkout ${latesttag}
+          fi
+          # if any ref was provided check it out
+          if [ "$REF" != "latest_tag" ]; then
+            echo "Checking out $REF"
+            git checkout $REF
+          fi
+        env:
+          REF: ${{ github.event.inputs.ref }}
+          ENV: ${{ github.event.inputs.environment }}
 
       - id: checkout-biomage-utils
         if: github.event.inputs.environment == 'staging'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ under the repository. You can launch the tests manually for
 each environment.
 
 A nightly test on the production environment only is also run
-at midnight every day automatically.
+at midnight every day automatically. This nightly build uses the latest
+tag on the master branch. If your changes do not depend on
+any repo's release you should create a new tag after merging.
 
 ### Running in staging
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ each environment.
 
 A nightly test on the production environment only is also run
 at midnight every day automatically. This nightly build uses the latest
-tag on the master branch. If your changes do not depend on
-any repo's release you should create a new tag after merging.
+tag on the master branch.  If your changes do not depend on any changes in another repo,
+you should create a new tag after merging.
 
 ### Running in staging
 


### PR DESCRIPTION
Now the nightly build which uses production env will use the latest tag instead of latest commit. This will prevent the tests from failing when we merge new changes that depend on UI code that is not yet released. 

The new paramter ref allows to override that behavior and run whichever commit, branch, or tag on the specified environment.