### PR TITLE
Reinsert fail check

### DIFF
--- a/e2e/cypress/integration/ui-smoke/ui-create-delete-metadata.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-create-delete-metadata.spec.js
@@ -2,6 +2,7 @@
 import '../../support/commands';
 import successResponse from '../../fixtures/successResponse.json';
 
+const resizeObserverLoopErrRe = /ResizeObserver loop limit exceeded/;
 const projectName = 'IntTest - Add Metadata Project';
 
 describe('Adds metadata to a sample in a created project', () => {
@@ -27,6 +28,14 @@ describe('Adds metadata to a sample in a created project', () => {
 
     cy.login();
     cy.visit('/data-management');
+  });
+
+  // we have some kind of resize observer loop error that needs looking into
+  Cypress.on('uncaught:exception', (err) => {
+    if (resizeObserverLoopErrRe.test(err.message)) {
+      return false;
+    }
+    return true;
   });
 
   it('creates a new metadata track', () => {

--- a/e2e/cypress/integration/ui-smoke/ui-create-project.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-create-project.spec.js
@@ -2,6 +2,7 @@
 import '../../support/commands';
 import successResponse from '../../fixtures/successResponse.json';
 
+const resizeObserverLoopErrRe = /ResizeObserver loop limit exceeded/;
 const projectName = 'Pequeninos Sample';
 const projectDescription = 'Tissue sample from varelse species known as pequeninos.';
 
@@ -28,6 +29,14 @@ describe('Creates a new project when authenticated', () => {
 
     cy.login();
     cy.visit('/data-management');
+  });
+
+  // we have some kind of resize observer loop error that needs looking into
+  Cypress.on('uncaught:exception', (err) => {
+    if (resizeObserverLoopErrRe.test(err.message)) {
+      return false;
+    }
+    return true;
   });
 
   it('creates a new project', () => {

--- a/e2e/cypress/integration/ui-smoke/ui-launch-analysis.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-launch-analysis.spec.js
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 import '../../support/commands';
 
+const resizeObserverLoopErrRe = /ResizeObserver loop limit exceeded/;
 const projectName = 'IntTest - Add Metadata Project';
 const gem2sTimeOut = (60 * 1000) * 20; // 20 minutes;
 const qcTimeOut = (60 * 1000) * 20; // 20 minutes;
@@ -29,6 +30,14 @@ describe('Launches analysis successfully', () => {
 
     cy.login();
     cy.visit('/data-management');
+  });
+
+  // we have some kind of resize observer loop error that needs looking into
+  Cypress.on('uncaught:exception', (err) => {
+    if (resizeObserverLoopErrRe.test(err.message)) {
+      return false;
+    }
+    return true;
   });
 
   it('launches analysis', () => {


### PR DESCRIPTION
# Background
#### Link to issue 

The check `ResizeObserverLoop` was removed because Iva's refactor caused it to go away when testing. However, it's coming back now, so the code to ignore the error has to be added again.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
